### PR TITLE
update(instance): avoid endless loops

### DIFF
--- a/instance.module
+++ b/instance.module
@@ -18,7 +18,8 @@ function instance_cron() {
     $dataTransmitter = new DataTransmitter();
     $dataTransmitter->transmitInstanceData($dataCollector->getData());
   } catch (Exception $e) {
-    \Drupal::messenger()->addError($e->getMessage());
-    \Drupal::logger('monitor')->error($e->getMessage());
+    // do nothing here to prevent endless loops
+    // later we could discuss to send an E-Mail?
+    // we should not log anything, cause the log will trigger a new transmit(), which can fail again and again and again
   }
 }

--- a/instance.module
+++ b/instance.module
@@ -19,7 +19,5 @@ function instance_cron() {
     $dataTransmitter->transmitInstanceData($dataCollector->getData());
   } catch (Exception $e) {
     // do nothing here to prevent endless loops
-    // later we could discuss to send an E-Mail?
-    // we should not log anything, cause the log will trigger a new transmit(), which can fail again and again and again
   }
 }

--- a/instance.services.yml
+++ b/instance.services.yml
@@ -5,6 +5,6 @@ services:
     class: Drupal\instance\DataTransmitter
   logger.instance_logger:
     class: Drupal\instance\Logger\InstanceLogger
-    arguments: ['@instance.data_collector', '@instance.data_transmitter', '@logger.log_message_parser']
+    arguments: ['@instance.data_collector', '@logger.log_message_parser']
     tags:
       - { name: logger }

--- a/src/DataCollector.php
+++ b/src/DataCollector.php
@@ -25,29 +25,29 @@ class DataCollector {
 
   public function getData(): array {
     return [
-      'project' => $this->getProject(),
-      'environment' => $this->getEnvironment(),
-      'data' => [
-        'host' => \Drupal::request()->getSchemeAndHttpHost(),
-        'drupal' => [
-          'version' => $this->getDrupalCoreVersion(),
-        ],
-        'php' => [
-          'version' => $this->getPHPVersion(),
-        ],
-        'git' => [
-          'head' => $this->getGitHead(),
-          'headUrl' => $this->getGitHeadUrl(),
-          'commit' => $this->getGitCommitId(),
-          'commitUrl' => $this->getGitCommitUrl(),
-          'commitDate' => $this->getGitCommitDate()
-        ],
-        'node' => [
-          'version' => $this->getNodeVersion(),
-        ],
-        'npm' => $this->getOutdatedNPMPackages(),
-        'timestamp' => time(),
-      ]
+        'project' => $this->getProject(),
+        'environment' => $this->getEnvironment(),
+        'data' => [
+            'host' => \Drupal::request()->getSchemeAndHttpHost(),
+            'drupal' => [
+                'version' => $this->getDrupalCoreVersion(),
+            ],
+            'php' => [
+                'version' => $this->getPHPVersion(),
+            ],
+            'git' => [
+                'head' => $this->getGitHead(),
+                'headUrl' => $this->getGitHeadUrl(),
+                'commit' => $this->getGitCommitId(),
+                'commitUrl' => $this->getGitCommitUrl(),
+                'commitDate' => $this->getGitCommitDate()
+            ],
+            'node' => [
+                'version' => $this->getNodeVersion(),
+            ],
+            'npm' => $this->getOutdatedNPMPackages(),
+            'timestamp' => time(),
+        ]
     ];
   }
 
@@ -89,7 +89,7 @@ class DataCollector {
     return $this->getGitUrl() . '/commit/' . $this->getGitCommitId();
   }
 
-  private function getGitCommitId(): string|null {
+  private function getGitCommitId(): string|null|false {
     return shell_exec('git rev-parse --short HEAD');
   }
 
@@ -102,7 +102,7 @@ class DataCollector {
    *
    * @return string
    */
-  private function getGitCommitDate(): string {
+  private function getGitCommitDate(): false|null|string {
     return shell_exec('git show -s --format=%cd --date=short ' . $this->getGitCommitId());
   }
 
@@ -110,6 +110,7 @@ class DataCollector {
     $remote = shell_exec('git config --get remote.origin.url');
 
     //if no origin detected, return null
+    if (!$remote) return null;
     if (!preg_match('/^(https?:\/\/|git@)(.+)(\/|:)(.+)\/(.+).git$/', $remote, $matches)) return null;
 
     $host = $matches[2];

--- a/src/DataTransmitter.php
+++ b/src/DataTransmitter.php
@@ -77,11 +77,11 @@ class DataTransmitter {
    */
   private function transmit(array $data, string $endpoint): bool {
     $response = $this->client->request('POST', $this->monitor . '/monitor' . $endpoint, [
-      'headers' => [
-        'Content-Type' => 'application/json',
-      ],
-      'auth' => [$this->user, $this->password],
-      'body' => json_encode($data)
+        'headers' => [
+            'Content-Type' => 'application/json',
+        ],
+        'auth' => [$this->user, $this->password],
+        'body' => json_encode($data)
     ]);
 
     return $response->getStatusCode() == 201;

--- a/src/Logger/InstanceLogger.php
+++ b/src/Logger/InstanceLogger.php
@@ -34,6 +34,8 @@ final class InstanceLogger implements LoggerInterface {
    * {@inheritdoc}
    */
   public function log($level, string|\Stringable $message, array $context = []): void {
+    // check if logs should be sent to monitor
+    // we need to not send them to avoid endless loops. The monitor module has set the flag to false for its logs
     if (array_key_exists(SendToMonitorFlag::SEND_TO_MONITOR_KEY->value, $context) && !$context[SendToMonitorFlag::SEND_TO_MONITOR_KEY->value]) return;
     //prevent instance from sending too much traffic, so we restrict it to error (3) or higher
     if($level > RfcLogLevel::ERROR) return;

--- a/src/Logger/InstanceLogger.php
+++ b/src/Logger/InstanceLogger.php
@@ -9,6 +9,7 @@ use Drupal\Core\Logger\RfcLoggerTrait;
 use Drupal\Core\Logger\RfcLogLevel;
 use Drupal\instance\DataCollector;
 use Drupal\instance\DataTransmitter;
+use Drupal\instance\SendToMonitorFlag;
 use GuzzleHttp\Exception\GuzzleException;
 use Psr\Log\LoggerInterface;
 
@@ -33,6 +34,7 @@ final class InstanceLogger implements LoggerInterface {
    * {@inheritdoc}
    */
   public function log($level, string|\Stringable $message, array $context = []): void {
+    if (array_key_exists(SendToMonitorFlag::SEND_TO_MONITOR_KEY->value, $context) && !$context[SendToMonitorFlag::SEND_TO_MONITOR_KEY->value]) return;
     //prevent instance from sending too much traffic, so we restrict it to error (3) or higher
     if($level > RfcLogLevel::ERROR) return;
 

--- a/src/SendToMonitorFlag.php
+++ b/src/SendToMonitorFlag.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Drupal\instance;
+
+enum SendToMonitorFlag: string {
+  case SEND_TO_MONITOR_KEY = 'sendToMonitor';
+}


### PR DESCRIPTION
don't log errors in transmitter methods
use a singleton transmitter
remove drupal messages to hide errors from users